### PR TITLE
Add new step to click the http link address in email

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,6 +722,9 @@ It's based on the `vendor/bin/behat -di @cms` output.
 
 	Then /^the email should (not |)be sent to "([^"]*)"$/
 
+    When /^I click on the http link "([^"]*)" in the email$/
+        - Example: When I click on the http link "http://localhost/changepassword" in the email
+ 
 ### Transformations
 
 Behat [transformations](http://docs.behat.org/guides/2.definitions.html#step-argument-transformations)

--- a/src/SilverStripe/BehatExtension/Context/EmailContext.php
+++ b/src/SilverStripe/BehatExtension/Context/EmailContext.php
@@ -313,4 +313,35 @@ class EmailContext extends BehatContext
             assertContains($to, $match->To);
         }
     }
+
+    /**
+     * The link text is the link address itself which contains special characters
+     * e.g. http://localhost/Security/changepassword?m=199&title=reset
+     * Example: When I click on the http link "changepassword" in the email
+     * @When /^I click on the http link "([^"]*)" in the email$/
+     */
+    public function iClickOnHttpLinkInEmail($httpText)
+    {
+        if (!$this->lastMatchedEmail) {
+            throw new \LogicException('No matched email found from previous step');
+        }
+
+        $email = $this->lastMatchedEmail;
+        $html = $email->Content;
+        $dom = new \DOMDocument();
+        $dom->loadHTML($html);
+
+        $tags = $dom->getElementsByTagName('a');
+        $href = null;
+        foreach ($tags as $tag) {
+            $linkText = $tag->nodeValue;
+            if (strpos($linkText, $httpText) !== false) {
+                $href = $linkText;
+                break;
+            }
+        }
+        assertNotNull($href);
+
+        return new Step\When(sprintf('I go to "%s"', $href));
+    }
 }


### PR DESCRIPTION
The existing step `I click on the "([^"]*)" link in the email` doesn't work for some special characters in the link text, e.g. the link text is as below in email:
`http://localhost/Security/changepassword?m=199&title=reset`
It doesn't match with anything like localhost, Security or changepassword, etc.