### PR TITLE
NEW: Add bootstrap_file extension parameter.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
 		"symfony/translation": "~2.0",
 		"symfony/yaml": "~2.0",
 		"symfony/finder": "~2.0",
-		"silverstripe/testsession": "*",
-		"silverstripe/framework": "^4.0.0"
+		"silverstripe/testsession": "^2.0.0-alpha2",
+		"silverstripe/framework": "^4.0.0-alpha2"
 	},
 
 	"autoload": {

--- a/src/SilverStripe/BehatExtension/Console/Processor/InitProcessor.php
+++ b/src/SilverStripe/BehatExtension/Console/Processor/InitProcessor.php
@@ -10,7 +10,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Behat\Behat\Console\Processor\InitProcessor as BaseProcessor;
 use SilverStripe\Core\Manifest\ClassLoader;
 
-
 /**
  * Initializes a project for Behat usage, creating context files.
  */

--- a/src/SilverStripe/BehatExtension/Context/BasicContext.php
+++ b/src/SilverStripe/BehatExtension/Context/BasicContext.php
@@ -10,7 +10,6 @@ use Behat\Mink\Driver\Selenium2Driver;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Filesystem;
 
-
 // PHPUnit
 require_once BASE_PATH . '/vendor/phpunit/phpunit/src/Framework/Assert/Functions.php';
 

--- a/src/SilverStripe/BehatExtension/Context/Initializer/SilverStripeAwareInitializer.php
+++ b/src/SilverStripe/BehatExtension/Context/Initializer/SilverStripeAwareInitializer.php
@@ -58,13 +58,18 @@ class SilverStripeAwareInitializer implements InitializerInterface
     protected $testSessionEnvironment;
 
     /**
+     * @var string PHP file to included before loading Core.php
+     */
+    protected $bootstrapFile;
+
+    /**
      * Initializes initializer.
      *
      * @param string $frameworkPath
      */
-    public function __construct($frameworkPath)
+    public function __construct($frameworkPath, $bootstrapFile = null)
     {
-        $this->bootstrap($frameworkPath);
+        $this->bootstrap($frameworkPath, $bootstrapFile);
 
         file_put_contents('php://stdout', "Creating test session environment" . PHP_EOL);
 
@@ -187,9 +192,14 @@ class SilverStripeAwareInitializer implements InitializerInterface
     /**
      * @param string $frameworkPath Absolute path to 'framework' module
      */
-    protected function bootstrap($frameworkPath)
+    protected function bootstrap($frameworkPath, $bootstrapFile = null)
     {
         file_put_contents('php://stdout', 'Bootstrapping' . PHP_EOL);
+
+        // Require a bootstrap file, if provided
+        if ($bootstrapFile) {
+            require_once($bootstrapFile);
+        }
 
         // Connect to database and build manifest
         $_GET['flush'] = 1;

--- a/src/SilverStripe/BehatExtension/Extension.php
+++ b/src/SilverStripe/BehatExtension/Extension.php
@@ -62,6 +62,7 @@ class Extension implements ExtensionInterface
         if (isset($config['region_map'])) {
             $container->setParameter('behat.silverstripe_extension.region_map', $config['region_map']);
         }
+        $container->setParameter('behat.silverstripe_extension.bootstrap_file', $config['bootstrap_file']);
     }
 
     /**
@@ -101,6 +102,9 @@ class Extension implements ExtensionInterface
                 end()->
                 scalarNode('ajax_timeout')->
                     defaultValue(5000)->
+                end()->
+                scalarNode('bootstrap_file')->
+                    defaultNull()->
                 end()->
                 arrayNode('ajax_steps')->
                     defaultValue(array(

--- a/src/SilverStripe/BehatExtension/services/silverstripe.yml
+++ b/src/SilverStripe/BehatExtension/services/silverstripe.yml
@@ -18,6 +18,7 @@ services:
     class: %behat.silverstripe_extension.context.initializer.class%
     arguments:
       - %behat.silverstripe_extension.framework_path%
+      - %behat.silverstripe_extension.bootstrap_file%
     calls:
       - [setAjaxSteps, [%behat.silverstripe_extension.ajax_steps%]]
       - [setAjaxTimeout, [%behat.silverstripe_extension.ajax_timeout%]]


### PR DESCRIPTION
The bootstrap_file parameter specifies a PHP file that will be included
between Constants.php (which is included by the composer autoloader)
and Core.php (which is included by SilverStripeAwareInitializer).

The goal of this setting is to provide a bit more flexibility about how
behat test environments are set up. It’s the logical companion of
PHPUnit’s bootstrap property.