### PR TITLE
API Bump minimum testsession version to 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"symfony/translation": "~2.0",
 		"symfony/yaml": "~2.0",
 		"symfony/finder": "~2.0",
-		"silverstripe/testsession": "*",
+		"silverstripe/testsession": "^2",
 		"silverstripe/framework": "^4.0.0"
 	},
 


### PR DESCRIPTION
I've also tagged https://github.com/silverstripe/silverstripe-testsession/releases/tag/2.0.0-alpha2 for the recent namespacing breaking changes.