### PR TITLE
Core reference fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.0.x-dev"
+			"dev-master": "2.1.x-dev"
 		}
 	},
 	"prefer-stable": true,

--- a/src/SilverStripe/BehatExtension/Compiler/CoreInitializationPass.php
+++ b/src/SilverStripe/BehatExtension/Compiler/CoreInitializationPass.php
@@ -19,9 +19,8 @@ class CoreInitializationPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         // Connect to database and build manifest
-        $frameworkPath = $container->getParameter('behat.silverstripe_extension.framework_path');
         $_GET['flush'] = 1;
-        require_once $frameworkPath . '/Core/Core.php';
+        require_once('Core/Core.php');
 
         SapphireTest::use_test_manifest();
 

--- a/src/SilverStripe/BehatExtension/Console/Processor/InitProcessor.php
+++ b/src/SilverStripe/BehatExtension/Console/Processor/InitProcessor.php
@@ -66,7 +66,7 @@ class InitProcessor extends BaseProcessor
         // Bootstrap SS so we can use module listing
         $frameworkPath = $this->container->getParameter('behat.silverstripe_extension.framework_path');
         $_GET['flush'] = 1;
-        require_once $frameworkPath . '/Core/Core.php';
+        require_once('Core/Core.php');
         unset($_GET['flush']);
 
         $featuresPath = $input->getArgument('features');

--- a/src/SilverStripe/BehatExtension/Context/Initializer/SilverStripeAwareInitializer.php
+++ b/src/SilverStripe/BehatExtension/Context/Initializer/SilverStripeAwareInitializer.php
@@ -203,7 +203,7 @@ class SilverStripeAwareInitializer implements InitializerInterface
 
         // Connect to database and build manifest
         $_GET['flush'] = 1;
-        require_once $frameworkPath . '/Core/Core.php';
+        require_once('Core/Core.php');
         unset($_GET['flush']);
 
         // Remove the error handler so that PHPUnit can add its own

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,4 +4,4 @@ $frameworkDir = basename($frameworkPath);
 if (!defined('BASE_PATH')) {
     define('BASE_PATH', dirname($frameworkPath));
 }
-require_once $frameworkPath . '/Core/Core.php';
+require_once 'Core/Core.php';


### PR DESCRIPTION
FIX: Reply on Core/Core.php being in include path.
This lets us change the location of Core.php as long as we also
manipulate the include path.

This is necessary for silverstripe/silverstripe-framework#6266

This also tags a `2.1.x-dev` alias as we've added new features since 2.0