### PR TITLE
FIX: Remove unnecessary dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,6 @@
 		"behat/mink-extension": "~1.3.0",
 		"behat/mink-selenium2-driver": "~1.2.0",
 		"symfony/dom-crawler": "~2.0",
-		"symfony/console": "~2.0",
-		"symfony/config": "~2.0",
-		"symfony/dependency-injection": "~2.0",
-		"symfony/event-dispatcher": "~2.0",
-		"symfony/translation": "~2.0",
-		"symfony/yaml": "~2.0",
-		"symfony/finder": "~2.0",
 		"silverstripe/testsession": "^2.0.0-alpha2",
 		"silverstripe/framework": "^4.0.0-alpha2"
 	},


### PR DESCRIPTION
These composer dependencies were inlined from Behat in an attempt to 
lock in PHP 5.3-compatible versions of Symfony packages. This is no
longer relevant and so we can remove this.

Please not that after this is merged, we should tag 2.2.3 against master