### PR TITLE
FIX: Allow pre-release versions of SS4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		"behat/mink-selenium2-driver": "~1.2.0",
 		"symfony/dom-crawler": "~2.0",
 		"silverstripe/testsession": "^2.0.0-alpha2",
-		"silverstripe/framework": "^4.0.0-alpha2"
+		"silverstripe/framework": "^4.0.0@dev"
 	},
 
 	"autoload": {


### PR DESCRIPTION
Since SS4 has not yet been released, and this module is used to test
pre-release versions of SS4, we need to have @dev on the requirement
to make it as flexible as possible.

As a general rule, modules that plug *into* SS4 rather than making *use*
of it should have @dev on the end of their dependencies.