### PR TITLE
BUG Ensure safe fallback for missing `.env` file to dev mode.

### DIFF
--- a/src/SilverStripe/BehatExtension/Compiler/CoreInitializationPass.php
+++ b/src/SilverStripe/BehatExtension/Compiler/CoreInitializationPass.php
@@ -20,6 +20,9 @@ class CoreInitializationPass implements CompilerPassInterface
     {
         // Connect to database and build manifest
         $_GET['flush'] = 1;
+        if (!getenv('SS_ENVIRONMENT_TYPE')) {
+            putenv('SS_ENVIRONMENT_TYPE=dev');
+        }
         require_once('Core/Core.php');
 
         // Include bootstrap file


### PR DESCRIPTION
The lack of this env var causes config bootstrapping to, occasionally, enter an infinite loop.