### PR TITLE
FIX: Soften coupling to SiteTree

### DIFF
--- a/src/Context/SilverStripeContext.php
+++ b/src/Context/SilverStripeContext.php
@@ -268,7 +268,9 @@ abstract class SilverStripeContext extends MinkContext implements SilverStripeAw
         }
         DataObject::flush_and_destroy_cache();
         DataObject::reset();
-        SiteTree::reset();
+        if (class_exists(SiteTree::class)) {
+            SiteTree::reset();
+        }
     }
 
     /**


### PR DESCRIPTION
The SiteTree link still exists but the module
will work if SiteTree isn’t installed.