### PR TITLE
BUG Prevent behat from always running root behat.yml fixtures

### DIFF
--- a/src/Context/LoginContext.php
+++ b/src/Context/LoginContext.php
@@ -4,9 +4,11 @@ namespace SilverStripe\BehatExtension\Context;
 
 use Behat\Behat\Context\Context;
 use Behat\Mink\Element\NodeElement;
+use SilverStripe\Security\Authenticator;
 use SilverStripe\Security\Group;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Permission;
+use SilverStripe\Security\Security;
 
 /**
  * LoginContext
@@ -127,7 +129,10 @@ class LoginContext implements Context
         /** @var Member $member */
         $member = Member::get()->filter('Email', $id)->First();
         assertNotNull($member);
-        assertTrue($member->checkPassword($password)->isValid());
+        $authenticators = Security::singleton()->getApplicableAuthenticators(Authenticator::CHECK_PASSWORD);
+        foreach ($authenticators as $authenticator) {
+            assertTrue($authenticator->checkPassword($member, $password)->isValid());
+        }
     }
 
     /**

--- a/src/Controllers/ModuleCommandTrait.php
+++ b/src/Controllers/ModuleCommandTrait.php
@@ -12,15 +12,16 @@ trait ModuleCommandTrait
      * Find target module being tested
      *
      * @param string $name
+     * @param bool $error Throw error if not found
      * @return Module
      */
-    protected function getModule($name)
+    protected function getModule($name, $error = true)
     {
         if (strpos($name, '@') === 0) {
             $name = substr($name, 1);
         }
         $module = ModuleLoader::inst()->getManifest()->getModule($name);
-        if (!$module) {
+        if (!$module && $error) {
             throw new InvalidArgumentException("No module $name installed");
         }
         return $module;

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -149,10 +149,8 @@ class Extension implements ExtensionInterface
             new Reference(SuiteExtension::REGISTRY_ID)
         ]);
         $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 9999]);
-        $container->setDefinition(CliExtension::CONTROLLER_TAG . '.sslocator', $definition);
+        $container->setDefinition(CliExtension::CONTROLLER_TAG . '.suite', $definition);
     }
-
-
 
     /**
      * Loads suite bootstrap controller.


### PR DESCRIPTION
From https://github.com/silverstripe/silverstripe-framework/issues/6387

The change is to, instead of adding a new controller, replace the core controller, and take over full control of loading suites.