### PR TITLE
NEW Adding abilility to add an extension in a step

### DIFF
--- a/src/Context/FixtureContext.php
+++ b/src/Context/FixtureContext.php
@@ -682,7 +682,7 @@ YAML;
         if (is_subclass_of($extension, DataExtension::class)) {
             $this->getMainContext()->visit('/dev/build?flush');
         } else {
-            $this->getMainContext()->visit('/flush');
+            $this->getMainContext()->visit('/?flush');
         }
     }
 


### PR DESCRIPTION
This PR adds the ability to add an extension to an object with a step in a feature file. This is especially useful when a module provides an extension for use, but doesn't apply it to any existing extensible objects by default.

Example: 
```
Given I add an extension "DNADesign\Elemental\Extensions\ElementalPageExtension" to the "Page" class
      And a "page" "Blocks Page" with a "Content Block" content element with "Some content" content
```