### PR TITLE
NEW Allows scenarios to anticipate an unsaved changes modal

### DIFF
--- a/src/Context/BasicContext.php
+++ b/src/Context/BasicContext.php
@@ -277,9 +277,11 @@ JS;
      */
     public function closeModalDialog(AfterScenarioScope $event)
     {
+        $expectsUnsavedChangesModal = $this->stepHasTag($event, 'unsavedChanges');
+        
         try {
             // Only for failed tests on CMS page
-            if ($event->getTestResult()->getResultCode() === TestResult::FAILED) {
+            if ($expectsUnsavedChangesModal || $event->getTestResult()->getResultCode() === TestResult::FAILED) {
                 $cmsElement = $this->getSession()->getPage()->find('css', '.cms');
                 if ($cmsElement) {
                     try {


### PR DESCRIPTION
This PR allows scenarios to tag themselves with `@unsavedChanges` meaning they will automatically dismiss any "Unsaved Changes!" modal that appears at the end of the test - preventing the error that could occur.