### PR TITLE
MINOR Increment testsession requirement for 4.1 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "behat/mink-extension": "^2.1",
         "silverstripe/mink-facebook-web-driver": "^1",
         "symfony/dom-crawler": "^3",
-        "silverstripe/testsession": "^2.1",
+        "silverstripe/testsession": "^2.2",
         "silverstripe/framework": "^4",
         "symfony/finder": "^3.2"
     },


### PR DESCRIPTION
Following #185, the behat extension needs `silverstripe/testsession` 2.2 or greater.

# Parent issue
* https://github.com/silverstripe/silverstripe-admin/issues/778