### PR TITLE
FIX | TestMailer uses new testsession APIs for handling state

### DIFF
--- a/src/Utility/TestMailer.php
+++ b/src/Utility/TestMailer.php
@@ -94,6 +94,6 @@ class TestMailer extends BaseTestMailer
             $state->emails = array();
         }
         $state->emails[] = array_filter($data);
-        $this->testSessionEnvironment->applyState($state);
+        $this->testSessionEnvironment->saveState($state);
     }
 }


### PR DESCRIPTION
This PR is a follow up on https://github.com/silverstripe/silverstripe-testsession/pull/65