### PR TITLE
BUG Update stepIPressTheButton to accept a list of button names separated by |

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-dist: precise
+dist: xenial
 
 sudo: false
 
@@ -29,7 +29,7 @@ before_script:
   - export PATH=~/.composer/vendor/bin:$PATH
   - composer validate
   - composer install --dev --prefer-dist
-  - composer require --prefer-dist --no-update silverstripe/recipe-core:1.0.x-dev
+  - composer require --prefer-dist --no-update silverstripe/recipe-core:^4
   - composer update
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
   - phpenv rehash

--- a/src/Context/BasicContext.php
+++ b/src/Context/BasicContext.php
@@ -443,6 +443,24 @@ JS;
     }
 
     /**
+     * @Given /^I press one of these buttons "([^"]*)"$/
+     * @param string $text A list of button names can be provided by seperating the entries with the | character.
+     */
+    public function stepIPressOneOfTheseButtons($text)
+    {
+        $buttonNames = explode('|', $text);
+        foreach ($buttonNames as $name) {
+            $button = $this->findNamedButton(trim($name));
+            if ($button) {
+                break;
+            }
+        }
+
+        assertNotNull($button, "{$text} button not found");
+        $button->click();
+    }
+
+    /**
      * Needs to be in single command to avoid "unexpected alert open" errors in Selenium.
      * Example1: I press the "Remove current combo" button, confirming the dialog
      * Example2: I follow the "Remove current combo" link, confirming the dialog

--- a/src/Context/BasicContext.php
+++ b/src/Context/BasicContext.php
@@ -443,10 +443,10 @@ JS;
     }
 
     /**
-     * @Given /^I press one of these buttons "([^"]*)"$/
+     * @Given /^I press the "([^"]*)" buttons$/
      * @param string $text A list of button names can be provided by seperating the entries with the | character.
      */
-    public function stepIPressOneOfTheseButtons($text)
+    public function stepIPressTheButtons($text)
     {
         $buttonNames = explode('|', $text);
         foreach ($buttonNames as $name) {


### PR DESCRIPTION
Minor tweak so multiple button name can be specified when calling the the `I press the "..." button` rule

# Related to
* https://github.com/silverstripe/silverstripe-admin/pull/956