### PR TITLE
Fix WebDriverSession autostart

### DIFF
--- a/src/Context/SilverStripeContext.php
+++ b/src/Context/SilverStripeContext.php
@@ -240,6 +240,11 @@ abstract class SilverStripeContext extends MinkContext implements SilverStripeAw
             );
         }
 
+        $webDriverSession = $this->getSession();
+        if (!$webDriverSession->isStarted()) {
+            $webDriverSession->start();
+        }
+
         $state = $this->getTestSessionState();
         $this->testSessionEnvironment->startTestSession($state);
 


### PR DESCRIPTION
Mink does not autostart web driver session anymore until the first ->visit invocation

Here's the breaking change: https://github.com/minkphp/Mink/commit/acf5fb1ec70b7de4902daf75301356702a26e6da

SilverStripeContext assumes the session is started when it prepares for the scenario (e.g. it may change the resolution)