### PR TITLE
Bump min-php and phpunit versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ cache:
     - $HOME/.composer/cache/files
 
 php:
-  - 7.1
   - 7.2
+  - 7.3
+  - 7.4
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,8 @@ env:
 before_script:
   - export PATH=~/.composer/vendor/bin:$PATH
   - composer validate
-  - composer install --dev --prefer-dist
   - composer require --prefer-dist --no-update silverstripe/recipe-core:5.x-dev
-  - composer update
+  - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
   - phpenv rehash
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
   - export PATH=~/.composer/vendor/bin:$PATH
   - composer validate
   - composer install --dev --prefer-dist
-  - composer require --prefer-dist --no-update silverstripe/recipe-core:2.x-dev
+  - composer require --prefer-dist --no-update silverstripe/recipe-core:5.x-dev
   - composer update
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
   - phpenv rehash

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
-        "phpunit/phpunit": "^7@dev",
+        "php": "^7.2",
+        "phpunit/phpunit": "^7 || ^8",
         "behat/behat": "^3.2",
         "behat/mink": "^1.7",
         "behat/mink-extension": "^2.1",

--- a/tests/php/SilverStripeContextTest.php
+++ b/tests/php/SilverStripeContextTest.php
@@ -8,6 +8,7 @@ use Behat\Mink\Session;
 use Behat\Mink\Mink;
 use Behat\Mink\Driver\DriverInterface;
 use Behat\Mink\Element\Element;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use SilverStripe\BehatExtension\Tests\SilverStripeContextTest\FeatureContext;
 use SilverStripe\Dev\SapphireTest;
@@ -17,7 +18,7 @@ class SilverStripeContextTest extends TestCase
 
     protected $backupGlobals = false;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         // Bootstrap test environment
         parent::setUpBeforeClass();
@@ -100,7 +101,7 @@ class SilverStripeContextTest extends TestCase
     }
 
     /**
-     * @return Element|\PHPUnit_Framework_MockObject_MockObject
+     * @return Element|MockObject
      */
     protected function getElementMock()
     {


### PR DESCRIPTION
PHPUnit 7 is no longer supported and there are bugs that we need to fix in the master test suites that fail because we aren't using phpunit 8